### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -5,7 +5,7 @@
 function hex2bin(hex: string) {
   const buf = new Uint8Array(Math.ceil(hex.length / 2));
   for (var i = 0; i < buf.length; i++) {
-    buf[i] = parseInt(hex.substr(i * 2, 2), 16);
+    buf[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
   }
   return buf;
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.